### PR TITLE
stop using the community module for lambda to eliminate dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Once this is done, Terraform can be applied to create the alerts, subscriptions,
 | <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | ~>0.48 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | 3.2.1 |
 
-In order to build the deployment package of the lambda function, access to python3 in the PATH is required.
 ## Providers
 
 | Name | Version |

--- a/data.tf
+++ b/data.tf
@@ -96,3 +96,23 @@ data "aws_iam_policy_document" "chatbot_channel_policy_document" {
     resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/chatbot/*"]
   }
 }
+
+data "archive_file" "lambda_deployment_package" {
+  type        = "zip"
+  source_dir = "${path.module}/lambda"
+  output_path = "${path.module}/cost_monitor.zip"
+  output_file_mode = "0666"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}


### PR DESCRIPTION
The current code uses a community module to create the lambda function. Although it's powerful, it adds a dependency. Python is required in the local environment or CI/CD runner in order to be able to build the lambda deployment package.
The lambda code was optimized to reduce every dependency therefore there's no need to install Python modules hence, the power of the community module is not needed. This PR eliminates the community module and replaces it with an aws_lambda_function resource in order to remove the Python dependency.