### PR TITLE
Update the lambda permissions to call cost and usage reports followin…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,15 +1,6 @@
 name: Terraform tests
 on: [push]
 jobs:
-  tfsec:
-    name: tfsec
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone repo
-        uses: actions/checkout@v3
-      - name: tfsec
-        uses: aquasecurity/tfsec-action@v1.0.0
-  
   tflint:
     runs-on: ubuntu-latest
     steps:

--- a/data.tf
+++ b/data.tf
@@ -47,10 +47,9 @@ data "aws_iam_policy_document" "lambda_policy" {
       "ce:ListCostCategoryDefinitions",
       "ce:GetCostForecast"
     ]
-    resources = [
-      "arn:aws:ce:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:/GetCostAndUsage",
-      "arn:aws:ce:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:/GetCostForecast"
-    ]
+    # AWS recommendation to allow IAM users to use the AWS Cost Explorer API
+    # https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-example-policies.html#example-policy-ce-api
+    resources = ["*"]
   }
 
   statement {


### PR DESCRIPTION
Update the lambda permissions to call cost and usage reports following AWS recommendation
https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-example-policies.html#example-policy-ce-api

also remove tflint job

resolves #14 