### PR TITLE
Use Threading to call AWS API and allow to configure lambda timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,13 @@ Once this is done, Terraform can be applied to create the alerts, subscriptions,
 
 | Name | Version |
 |------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.4.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.63 |
 | <a name="provider_awscc"></a> [awscc](#provider\_awscc) | ~>0.48 |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | 5.0.0 |
+No modules.
 
 ## Resources
 
@@ -78,11 +77,15 @@ Once this is done, Terraform can be applied to create the alerts, subscriptions,
 | [aws_cloudwatch_event_target.event_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_iam_policy.chatbot_channel_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.chatbot_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.iam_for_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.chatbot_role_attachement](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_function.cost_alert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.allow_events_bridge_to_run_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_sns_topic.cost_anomaly_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [awscc_chatbot_slack_channel_configuration.chatbot_slack_channel](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/chatbot_slack_channel_configuration) | resource |
+| [archive_file.lambda_deployment_package](https://registry.terraform.io/providers/hashicorp/archive/2.4.0/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.chatbot_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.chatbot_channel_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -98,6 +101,7 @@ Once this is done, Terraform can be applied to create the alerts, subscriptions,
 | <a name="input_deploy_lambda"></a> [deploy\_lambda](#input\_deploy\_lambda) | flag to choose if the lambda will be deployed or not | `bool` | `true` | no |
 | <a name="input_enable_slack_integration"></a> [enable\_slack\_integration](#input\_enable\_slack\_integration) | Set to false if slack integration is not needed and another subscriber to the SNS topic is preferred | `bool` | `true` | no |
 | <a name="input_lambda_frequency"></a> [lambda\_frequency](#input\_lambda\_frequency) | Frequency to run the lambda (cron formating is also accepted) | `string` | `"cron(0 13 ? * MON *)"` | no |
+| <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | maximum amount of time in seconds that the Lambda function can run | `number` | `5` | no |
 | <a name="input_name"></a> [name](#input\_name) | name for the monitors, topic, etc | `string` | `"cost-anomaly-monitor"` | no |
 | <a name="input_slack_channel_id"></a> [slack\_channel\_id](#input\_slack\_channel\_id) | right click on the channel name, copy channel URL, and use the letters and number after the last / | `string` | n/a | yes |
 | <a name="input_slack_workspace_id"></a> [slack\_workspace\_id](#input\_slack\_workspace\_id) | ID of your slack slack\_workspace\_id | `string` | n/a | yes |

--- a/data.tf
+++ b/data.tf
@@ -97,9 +97,9 @@ data "aws_iam_policy_document" "chatbot_channel_policy_document" {
 }
 
 data "archive_file" "lambda_deployment_package" {
-  type        = "zip"
-  source_dir = "${path.module}/lambda"
-  output_path = "${path.module}/cost_monitor.zip"
+  type             = "zip"
+  source_dir       = "${path.module}/lambda"
+  output_path      = "${path.module}/cost_monitor.zip"
   output_file_mode = "0666"
 }
 

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -93,7 +93,6 @@ def calculate_dates():
     """
     logger.info('Calculating cost')
     today = datetime.now()
-    threads = []
     
     # current month dates
     first_day_current_month = date(today.year, today.month, 1)

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -9,12 +9,13 @@ import threading
 from datetime import date, timedelta, datetime
 from os import environ
 
+
 # Get aws session
 session = boto3.session.Session()
 # Get lambda default logger handler
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
-
+# Global variables
 previous_month_cost = 0
 current_month_cost = 0
 forecasted_cost = 0

--- a/main.tf
+++ b/main.tf
@@ -121,6 +121,7 @@ resource "aws_lambda_function" "cost_alert" {
   handler          = "main.lambda_handler"
   runtime          = "python3.9"
   source_code_hash = data.archive_file.lambda_deployment_package.output_base64sha256
+  timeout          = var.lambda_timeout
   environment {
     variables = {
       "SNS_TOPIC_ARN" = var.sns_topic_arn != "" ? var.sns_topic_arn : aws_sns_topic.cost_anomaly_topic[0].arn # Do not change the key. It's used by the lambda

--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "lambda_frequency" {
 variable "lambda_timeout" {
   description = "maximum amount of time in seconds that the Lambda function can run"
   type        = number
-  default     = 5
+  default     = 3
   validation {
     condition     = var.lambda_timeout > 0 && var.lambda_timeout <= 900
     error_message = "timeout value must be higher than 0 seconds and lower or equal than 900 seconds (15 minutes)"

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,12 @@ variable "lambda_frequency" {
   type        = string
   default     = "cron(0 13 ? * MON *)" # defaults to Mondays 9:00 am ET (13 UTC)
 }
+variable "lambda_timeout" {
+  description = "maximum amount of time in seconds that the Lambda function can run"
+  type        = number
+  default     = 5
+  validation {
+    condition     = var.lambda_timeout > 0 && var.lambda_timeout <= 900
+    error_message = "timeout value must be higher than 0 seconds and lower or equal than 900 seconds (15 minutes)"
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -11,11 +11,11 @@ terraform {
       version = "~>0.48"
     }
     null = {
-      source = "hashicorp/null"
+      source  = "hashicorp/null"
       version = "3.2.1"
     }
     archive = {
-      source = "hashicorp/archive"
+      source  = "hashicorp/archive"
       version = "2.4.0"
     }
   }


### PR DESCRIPTION
Use Threading to call AWS API in order to optimize the execution time.
Allow to configure lambda timeout