### PR TITLE
[TER-6]: include a step for unit tests in the terraform aws cost anomaly detection modules pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# every memeber from the Terraform Community Admins will be requested
+# for review when someone opens a pull request.
+*       @caylent/terraform-community-admins

--- a/.github/workflows/lambda-unit-test.yaml
+++ b/.github/workflows/lambda-unit-test.yaml
@@ -1,6 +1,10 @@
 name: Python Tests
-on: [push]
-
+on:
+  push:
+    branches:
+      - main
+  pull_request: 
+      
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lambda-unit-test.yaml
+++ b/.github/workflows/lambda-unit-test.yaml
@@ -22,3 +22,5 @@ jobs:
     - name: Run tests
       run: |
         python3 -m pytest -v -s tests
+        coverage run -m unittest discover
+        coverage report --omit "/opt/*","*init*","tests/*" -m --fail-under=80


### PR DESCRIPTION
Run coverage command to generate a report on Lambda Python tests and fail if the value is under 80%