### PR TITLE
updating to allow newer versions of the aws provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.63"
+      version = ">= 4.63"
     }
     awscc = {
       source  = "hashicorp/awscc"


### PR DESCRIPTION
When attempting to use this module with a newer version of the aws provider you will get errors like: 
```
│ Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/aws: no available releases match the given constraints ...
```